### PR TITLE
feat: add /synthesize command to close development loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This system transforms the requirements gathering process by:
 - **Two-Phase Questioning**: 5 high-level questions for context, then 5 expert questions after code analysis  
 - **Automated Documentation**: Generates comprehensive specs with specific file paths and patterns
 - **Product Manager Friendly**: No code knowledge required to answer questions
+- **Complete Development Loop**: New `/synthesize` command transforms requirements into implementation
 
 ## 🚀 Quick Start
 
@@ -29,6 +30,9 @@ This system transforms the requirements gathering process by:
 # End current requirement gathering
 /requirements-end
 
+# Generate implementation plan from completed requirements
+/synthesize
+
 # Quick reminder if AI strays off course
 /remind
 ```
@@ -43,7 +47,8 @@ claude-requirements/
 │   ├── requirements-current.md  # View active requirement
 │   ├── requirements-end.md      # Finalize requirement
 │   ├── requirements-list.md     # List all requirements
-│   └── requirements-remind.md   # Remind AI of rules
+│   ├── requirements-remind.md   # Remind AI of rules
+│   └── synthesize.md           # Generate implementation from requirements
 │
 ├── requirements/                 # Requirement documentation storage
 │   ├── .current-requirement     # Tracks active requirement
@@ -164,6 +169,27 @@ Reminds AI to follow requirements gathering rules.
 - Asks open-ended questions
 - Starts implementing code
 - Asks multiple questions at once
+
+### `/synthesize`
+Transforms completed requirements into actionable implementation plans.
+
+**Features:**
+- Finds most recent completed requirement automatically
+- Generates phased implementation plan
+- Creates tracked todo list with specific tasks
+- Maps tasks to requirement IDs (FR/TR)
+- Begins actual implementation with progress tracking
+
+**Example:**
+```
+/synthesize
+```
+
+**Output:**
+- Implementation plan document
+- Todo list with task IDs
+- Automatic loading into Claude's task tracker
+- Begins implementation immediately
 
 ## 🎯 Features
 

--- a/commands/synthesize.md
+++ b/commands/synthesize.md
@@ -1,0 +1,146 @@
+# Synthesize Requirements into Implementation
+
+Analyzes completed requirements and generates a detailed implementation plan with tracked todo steps
+
+aliases: synth, implement
+
+## Instructions
+
+When the user runs the `synthesize` command:
+
+1. **Enter Planning Mode**
+   - Activate Claude's planning mode to ensure thoughtful analysis
+   - Prepare for comprehensive requirements review and implementation planning
+
+2. **Find Most Recent Completed Requirements**
+   - Navigate to `requirements/` directory in the current working directory
+   - Look for subdirectories with timestamp format (YYYY-MM-DD_HH-MM-SS_*)
+   - Find the most recent directory containing a `metadata.json` with `"status": "complete"`
+   - Extract the requirement name from the directory (part after timestamp)
+
+3. **Load and Analyze Requirements**
+   - Read `06-requirements-spec.md` from the identified directory
+   - Parse the following sections:
+     - Problem Statement
+     - Solution Overview
+     - Functional Requirements (FR*)
+     - Technical Requirements (TR*)
+     - Implementation Hints
+     - Acceptance Criteria
+   - Read `03-context-findings.md` for technical context
+   - Read `metadata.json` for related features and context files
+
+4. **Generate Implementation Plan**
+   Create a detailed implementation plan with the following structure:
+   ```markdown
+   # Implementation Plan: [Requirement Name]
+   Generated: [Current Timestamp]
+   Based on: [Original Requirements Timestamp]
+
+   ## Overview
+   [Brief summary of what will be implemented]
+
+   ## Prerequisites
+   - [ ] List any setup requirements
+   - [ ] Dependencies to install
+   - [ ] Files to create/modify
+
+   ## Implementation Phases
+
+   ### Phase 1: [Foundation/Setup]
+   **Objective**: [What this phase accomplishes]
+   **Requirements Addressed**: [FR/TR numbers]
+   
+   Steps:
+   1. [Specific action with file:line references]
+   2. [Next action]
+   ...
+
+   ### Phase 2: [Core Implementation]
+   [Continue pattern for each logical phase]
+
+   ## Testing Strategy
+   - Unit tests for [components]
+   - Integration tests for [features]
+   - Manual testing checklist
+
+   ## Validation Against Acceptance Criteria
+   [Map each acceptance criterion to implementation steps]
+   ```
+
+5. **Generate Todo List**
+   Create a structured todo list from the implementation plan:
+   ```markdown
+   # Implementation Todo: [Requirement Name]
+   Generated: [Current Timestamp]
+   Total Steps: [Number]
+
+   ## Setup Tasks
+   - [ ] SETUP-1: [Task description] | File: [path] | Priority: High
+   - [ ] SETUP-2: [Task description] | File: [path] | Priority: High
+
+   ## Phase 1 Tasks
+   - [ ] P1-1: [Task description] | File: [path] | Priority: High
+   - [ ] P1-2: [Task description] | File: [path] | Priority: Medium
+   
+   ## Phase 2 Tasks
+   [Continue pattern]
+
+   ## Testing Tasks
+   - [ ] TEST-1: [Test description] | Type: [unit/integration/manual]
+   
+   ## Validation Tasks
+   - [ ] VAL-1: Verify [acceptance criterion]
+   ```
+
+6. **Save Plan and Todo List**
+   - Create subdirectory: `[requirements-dir]/implementation/`
+   - Save files with timestamps:
+     - `implementation-plan_[timestamp].md`
+     - `implementation-todo_[timestamp].md`
+   - Create a `current` symlink to latest files for easy access
+
+7. **Begin Implementation**
+   - Exit planning mode with the generated plan
+   - Load the todo list into Claude's TodoWrite tool
+   - Start with SETUP tasks, marking each as `in_progress` then `completed`
+   - Follow any project-specific guidance from CLAUDE.md if present
+   - For each task:
+     1. Mark as `in_progress` in TodoWrite
+     2. Implement the specific change
+     3. Run any relevant tests/lints
+     4. Mark as `completed` in TodoWrite
+     5. Update the saved todo file with completion status
+
+8. **Progress Tracking**
+   - Periodically save progress to `implementation-todo_[timestamp].md`
+   - Add completion timestamps to finished items
+   - If blocked on any task, add a `BLOCKED:` prefix and explanation
+   - Create `implementation-notes_[timestamp].md` for any discoveries or changes
+
+## Error Handling
+
+- If no completed requirements found: "No completed requirements found in requirements/"
+- If requirements incomplete: "Found requirement [name] but status is [status], not 'complete'"
+- If missing required files: List which files are missing from the requirement
+
+## Example Usage
+
+```
+synthesize
+```
+
+This will:
+1. Find the most recent completed requirement in `requirements/`
+2. Generate a detailed implementation plan
+3. Create a todo list with specific tasks
+4. Save both in the requirements directory
+5. Begin implementing while tracking progress
+
+## Notes
+
+- The command respects any coding standards in the project's CLAUDE.md file
+- Each task in the todo list maps to specific requirement items (FR/TR)
+- Progress is saved incrementally to prevent loss of work
+- The implementation follows the phases defined in the plan
+- Testing and validation are integrated into the workflow


### PR DESCRIPTION
## Summary
- Add new `/synthesize` command that transforms completed requirements into actionable implementation plans
- Command automatically finds the most recent completed requirement in the `requirements/` directory
- Generates phased implementation plan with tracked todo list, mapping tasks to specific requirement IDs

## What This PR Adds

The `/synthesize` command completes the full development loop for the requirements builder system:
1. `/requirements-start` - Begin gathering requirements
2. `/requirements-end` - Finalize requirements with status "complete"
3. `/synthesize` - Transform requirements into implementation (NEW)

### Key Features
- Works from current working directory (no path argument needed)
- Automatically enters Claude's planning mode for thoughtful analysis
- Generates detailed implementation plan with phases
- Creates tracked todo list with task IDs (SETUP-1, P1-1, TEST-1, etc.)
- Maps each task to specific functional/technical requirements
- Begins actual implementation with progress tracking
- Saves plans in `requirements/[requirement]/implementation/` directory

## Test Plan
- [x] Run `/synthesize` in a project with completed requirements
- [x] Verify it finds the most recent completed requirement
- [x] Confirm implementation plan is generated with proper structure
- [x] Check that todo list is created and loaded into Claude's task tracker
- [x] Verify error handling for missing or incomplete requirements

🤖 Generated with [Claude Code](https://claude.ai/code)